### PR TITLE
Curriculum toggle show more

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "payment": "^2.3.0",
     "pre-commit": "^1.2.2",
     "prop-types": "^15.6.2",
+    "query-string": "^6.2.0",
     "raven-js": "^3.26.4",
     "react-apollo": "^2.1.9",
     "react-burger-menu": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "payment": "^2.3.0",
     "pre-commit": "^1.2.2",
     "prop-types": "^15.6.2",
-    "query-string": "^6.2.0",
     "raven-js": "^3.26.4",
     "react-apollo": "^2.1.9",
     "react-burger-menu": "^2.5.2",
@@ -48,7 +47,8 @@
     "react-width": "^0.1.8",
     "rehype-react": "^3.0.3",
     "store": "^2.0.12",
-    "styled-components": "^3.3.3"
+    "styled-components": "^3.3.3",
+    "url-search-params-polyfill": "^5.0.0"
   },
   "keywords": [
     "gatsby"

--- a/src/components/curriculum/CurriculumAdvancedReact.js
+++ b/src/components/curriculum/CurriculumAdvancedReact.js
@@ -12,19 +12,25 @@ import CompoundCompAndContextSession from './sessions/CompoundCompAndContextSess
 import ServerSideRenderingSession from './sessions/ServerSideRenderingSession'
 import Hackathon from './sessions/Hackathon'
 import SectionCTA from './SectionCTA'
-import { UpcomingTrainingSection } from '../training';
-import { ADVANCED_REACT } from '../../config/data';
+import { UpcomingTrainingSection } from '../training'
+import { ADVANCED_REACT } from '../../config/data'
 
 const CurriculumAdvancedReact = ({
   showTitle = true,
+  isOpen,
   list,
-  showToggle,
+  enableToggle,
   toggleNavigateTo = `/curriculum?tab=${ADVANCED_REACT}`,
   marketingCard = null,
   showLinkToCurriculum = true,
 }) => {
   const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
-  const commonProps = { showToggle, toggleNavigateTo: toggleNavigateToSection, type: ADVANCED_REACT }
+  const commonProps = {
+    enableToggle,
+    toggleNavigateTo: toggleNavigateToSection,
+    type: ADVANCED_REACT,
+    isOpen,
+  }
   const firstHalf = (
     <React.Fragment>
       <Section

--- a/src/components/curriculum/CurriculumBootcamp.js
+++ b/src/components/curriculum/CurriculumBootcamp.js
@@ -1,7 +1,6 @@
 import React from 'react'
-
 import Link from '../navigation/Link'
-import { H2Ref, H3 } from '../text'
+import { H2Ref } from '../text'
 import Section, { List, curriedToggleNavigateTo } from './CurriculumSection'
 import { Col, Row } from '../layout/Grid'
 import ES6Session from './sessions/ES6Session'
@@ -22,19 +21,25 @@ import ServerSideRenderingSession from './sessions/ServerSideRenderingSession'
 import Hackathon from './sessions/Hackathon'
 import { LinkButton } from '../buttons'
 import SectionCTA from './SectionCTA'
-import { UpcomingTrainingSection } from '../training';
-import { REACT_BOOTCAMP } from '../../config/data';
+import { UpcomingTrainingSection } from '../training'
+import { REACT_BOOTCAMP } from '../../config/data'
 
 const CurriculumBootcamp = ({
   showTitle = true,
   list,
-  showToggle,
+  enableToggle,
+  isOpen,
   toggleNavigateTo = `/curriculum?tab=${REACT_BOOTCAMP}`,
   marketingCard = null,
   showLinkToCurriculum = true,
 }) => {
   const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
-  const commonProps = { showToggle, toggleNavigateTo: toggleNavigateToSection, type: REACT_BOOTCAMP }
+  const commonProps = {
+    enableToggle,
+    toggleNavigateTo: toggleNavigateToSection,
+    type: REACT_BOOTCAMP,
+    isOpen,
+  }
   const firstHalf = (
     <React.Fragment>
       <Section

--- a/src/components/curriculum/CurriculumCorpTraining.js
+++ b/src/components/curriculum/CurriculumCorpTraining.js
@@ -24,13 +24,18 @@ import { REACT_BOOTCAMP } from '../../config/data'
 const CurriculumBootcamp = ({
   showTitle = true,
   list,
-  showToggle,
+  isOpen,
+  enableToggle,
   toggleNavigateTo = `/curriculum?tab=${REACT_BOOTCAMP}`,
   marketingCard = null,
   showLinkToCurriculum = true,
 }) => {
   const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
-  const commonProps = { showToggle, toggleNavigateTo: toggleNavigateToSection }
+  const commonProps = {
+    enableToggle,
+    toggleNavigateTo: toggleNavigateToSection,
+    isOpen,
+  }
   const firstHalf = (
     <React.Fragment>
       <Section

--- a/src/components/curriculum/CurriculumCorporate.js
+++ b/src/components/curriculum/CurriculumCorporate.js
@@ -71,7 +71,7 @@ const CurriculumCorporate = ({
         <IntroReduxSession title="Introduction to Redux" />
         <TestingIntroSession title="Testing Principales" />
       </Section>
-      
+
       {marketingCard}
     </React.Fragment>
   )
@@ -100,13 +100,13 @@ const CurriculumCorporate = ({
         />
         <AdvancedReduxSession title="Functional programming & advanced Redux" />
       </Section>
-      {showLinkToCurriculum?(
+      {showLinkToCurriculum ? (
         <SectionCTA>
           <LinkButton secondary to="/curriculum">
             Full curriculum>>
           </LinkButton>
         </SectionCTA>
-      ):null}
+      ) : null}
     </React.Fragment>
   )
 

--- a/src/components/curriculum/CurriculumPartTime.js
+++ b/src/components/curriculum/CurriculumPartTime.js
@@ -15,8 +15,8 @@ import IntroReduxSession from './sessions/IntroReduxSession'
 import TestingIntroSession from './sessions/TestingIntroSession'
 import HoCsAndRenderPropsSession from './sessions/HoCsAndRenderPropsSession'
 import CurriculumCard from './CurriculumCard'
-import { UpcomingTrainingSection } from '../training';
-import { PART_TIME } from '../../config/data';
+import { UpcomingTrainingSection } from '../training'
+import { PART_TIME } from '../../config/data'
 
 const PartTimeFinalProject = () => (
   <Ul>
@@ -33,14 +33,20 @@ const PartTimeFinalProject = () => (
 
 const CurriculumPartTime = ({
   showTitle = true,
+  isOpen,
   list,
-  showToggle,
+  enableToggle,
   toggleNavigateTo = `/curriculum?tab=${PART_TIME}`,
   showCallToActionBottom = false,
   marketingCard = null,
 }) => {
   const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
-  const commonProps = { showToggle, toggleNavigateTo: toggleNavigateToSection, type: PART_TIME }
+  const commonProps = {
+    enableToggle,
+    toggleNavigateTo: toggleNavigateToSection,
+    type: PART_TIME,
+    isOpen,
+  }
   const firstHalf = (
     <React.Fragment>
       <Section

--- a/src/components/curriculum/CurriculumReactNative.js
+++ b/src/components/curriculum/CurriculumReactNative.js
@@ -7,16 +7,22 @@ import { UpcomingTrainingSection } from '../training'
 import ReactNativeFoundationSession from './sessions/native/ReactNativeFoundationSession'
 import ReactNativeNavigationSession from './sessions/native/ReactNativeNavigationSession'
 import ReactNativeAnimationsSession from './sessions/native/ReactNativeAnimationsSession'
-import { REACT_NATIVE } from '../../config/data';
+import { REACT_NATIVE } from '../../config/data'
 
 const CurriculumReactNative = ({
   showTitle = true,
   list,
-  showToggle,
+  enableToggle,
+  isOpen,
   toggleNavigateTo = `/curriculum?tab=${REACT_NATIVE}`,
 }) => {
   const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
-  const commonProps = { showToggle, toggleNavigateTo: toggleNavigateToSection, type: REACT_NATIVE }
+  const commonProps = {
+    enableToggle,
+    toggleNavigateTo: toggleNavigateToSection,
+    type: REACT_NATIVE,
+    isOpen,
+  }
   const firstHalf = (
     <Section
       {...commonProps}

--- a/src/components/curriculum/CurriculumSection.js
+++ b/src/components/curriculum/CurriculumSection.js
@@ -107,7 +107,7 @@ class CurriculumSection extends React.Component {
     ) : (
       <React.Fragment>
         <Span> - </Span>
-        <Link {...toogleLinkProps}>More detail</Link>
+        <Link {...toogleLinkProps}>Full detail</Link>
       </React.Fragment>
     )
 

--- a/src/components/curriculum/CurriculumSection.js
+++ b/src/components/curriculum/CurriculumSection.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import styled from 'styled-components'
-import queryString from 'query-string'
 import { H4 } from '../text'
 import { withRouter } from 'react-router-dom'
 import { FONT_FAMILY } from '../../config/styles'

--- a/src/components/curriculum/CurriculumSection.js
+++ b/src/components/curriculum/CurriculumSection.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { H4 } from '../text'
+import { H4, Span } from '../text'
 import { withRouter } from 'react-router-dom'
 import { FONT_FAMILY } from '../../config/styles'
 import { Element } from 'react-scroll'
@@ -95,7 +95,7 @@ class CurriculumSection extends React.Component {
     const subsection = isOpen ? (
       <CurriculumSubSection>
         {children}
-        <span> - </span>
+        <Span> - </Span>
         <Link
           duration={200}
           to={`#${name || title}`}
@@ -106,7 +106,7 @@ class CurriculumSection extends React.Component {
       </CurriculumSubSection>
     ) : (
       <React.Fragment>
-        <span> - </span>
+        <Span> - </Span>
         <Link {...toogleLinkProps}>More detail</Link>
       </React.Fragment>
     )

--- a/src/components/curriculum/CurriculumSection.js
+++ b/src/components/curriculum/CurriculumSection.js
@@ -10,6 +10,7 @@ import trackUserBehaviour, {
   CURRICULUM_MORE_DETAILS,
 } from '../utils/trackUserBehaviour'
 import { selectTypeColor } from '../utils'
+import 'url-search-params-polyfill'
 
 export const curriedToggleNavigateTo = to => section =>
   to ? `${to}&section=${section}` : false
@@ -42,9 +43,13 @@ class CurriculumSection extends React.Component {
   constructor(props) {
     super(props)
 
-    const { section, tab } = queryString.parse(props.location.search) || {}
+    const queryString = props.location.search.replace('?', '')
+    const params = new URLSearchParams(queryString)
     this.state = {
-      isOpen: props.isOpen || (section === props.name && tab === props.type),
+      isOpen:
+        props.isOpen ||
+        (params.get('section') === props.name &&
+          params.get('tab') === props.type),
     }
   }
 

--- a/src/components/curriculum/CurriculumSection.js
+++ b/src/components/curriculum/CurriculumSection.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
-import { H4, P } from '../text'
+import queryString from 'query-string'
+import { H4 } from '../text'
+import { withRouter } from 'react-router-dom'
 import { FONT_FAMILY } from '../../config/styles'
 import { Element } from 'react-scroll'
 import { Link } from '../navigation'
@@ -12,12 +14,9 @@ import { selectTypeColor } from '../utils'
 export const curriedToggleNavigateTo = to => section =>
   to ? `${to}&section=${section}` : false
 
-
 const Section = styled.div`
-  ${props => 
-    `border-left: 3px solid ${selectTypeColor(props.type)};`
-  }
-  margin-top: 2em;
+  ${props =>
+    `border-left: 3px solid ${selectTypeColor(props.type)};`} margin-top: 2em;
   padding-left: 20px;
 `
 
@@ -32,27 +31,28 @@ export const List = styled.div`
 const CurriculumItemTitle = styled(H4)`
   margin-bottom: 0.5em;
 `
-const SubTitleSection = styled.div` 
+const SubTitleSection = styled.div`
   margin: 0;
   padding-bottom: 18px;
   line-height: 1.5;
-  ${FONT_FAMILY}
+  ${FONT_FAMILY};
 `
 
 class CurriculumSection extends React.Component {
   constructor(props) {
     super(props)
 
+    const { section, tab } = queryString.parse(props.location.search) || {}
     this.state = {
-      isOpen: props.isOpen || false,
+      isOpen: props.isOpen || (section === props.name && tab === props.type),
     }
   }
 
   toggleSubSection = () => {
     this.setState(
-      {
-        isOpen: !this.state.isOpen,
-      },
+      state => ({
+        isOpen: !state.isOpen,
+      }),
       () => {
         if (this.state.isOpen) {
           // send event to analytics
@@ -75,30 +75,36 @@ class CurriculumSection extends React.Component {
       type,
       subTitle,
       children,
-      showToggle = true,
+      enableToggle = false,
       toggleNavigateTo,
     } = this.props
     const { toggleSubSection } = this
-    const toogleLinkProps = toggleNavigateTo
-      ? {
-          to:
-            typeof toggleNavigateTo === 'function'
-              ? toggleNavigateTo(name)
-              : toggleNavigateTo,
-        }
-      : { onClick: toggleSubSection }
-    const childrenWithToggle = isOpen ? (
+    const toogleLinkProps =
+      toggleNavigateTo && !enableToggle
+        ? {
+            to:
+              typeof toggleNavigateTo === 'function'
+                ? toggleNavigateTo(name)
+                : toggleNavigateTo,
+          }
+        : { onClick: toggleSubSection }
+    const subsection = isOpen ? (
       <CurriculumSubSection>
         {children}
-        <Link duration={500} to={name || title} onClick={toggleSubSection}>
+        <span> - </span>
+        <Link
+          duration={200}
+          to={`#${name || title}`}
+          onClick={toggleSubSection}
+        >
           Hide detail
         </Link>
       </CurriculumSubSection>
     ) : (
-      <Link {...toogleLinkProps}>More detail</Link>
-    )
-    const childrenWithoutToggle = (
-      <CurriculumSubSection>{children}</CurriculumSubSection>
+      <React.Fragment>
+        <span> - </span>
+        <Link {...toogleLinkProps}>More detail</Link>
+      </React.Fragment>
     )
 
     return (
@@ -106,12 +112,12 @@ class CurriculumSection extends React.Component {
         <Element name={name || title} />
         {title ? <CurriculumItemTitle>{title}</CurriculumItemTitle> : ''}
         <SubTitleSection>
-        {`${subTitle ? subTitle : ''} - `}
-        {showToggle ? childrenWithToggle : childrenWithoutToggle}
-        </SubTitleSection> 
+          {subTitle ? subTitle : ''}
+          {subsection}
+        </SubTitleSection>
       </Section>
     )
   }
 }
 
-export default CurriculumSection
+export default withRouter(CurriculumSection)

--- a/src/components/curriculum/FullCurriculum.js
+++ b/src/components/curriculum/FullCurriculum.js
@@ -2,31 +2,29 @@ import React from 'react'
 import { Col, Row } from '../layout/Grid'
 import { H1Ref, P } from '../text'
 import Link from '../navigation/Link'
+import { Tabs, TabList, TabItem, TabContent, ContentItem } from '../navigation'
 import {
-  Tabs,
-  TabList,
-  TabItem,
-  TabContent,
-  ContentItem
-} from '../navigation'
-import {
-  CurriculumBootcamp, 
+  CurriculumBootcamp,
   CurriculumPartTime,
   CurriculumReactNative,
   CurriculumAdvancedReact,
-} from './index' 
-import { REACT_NATIVE, REACT_BOOTCAMP, PART_TIME, ADVANCED_REACT } from '../../config/data';
-
+} from './index'
+import {
+  REACT_NATIVE,
+  REACT_BOOTCAMP,
+  PART_TIME,
+  ADVANCED_REACT,
+} from '../../config/data'
 
 class FullCurriculum extends React.Component {
   state = {
     active: REACT_BOOTCAMP,
   }
-  
+
   setActive = active => {
     this.setState({ active })
   }
-  
+
   render() {
     return (
       <React.Fragment>
@@ -40,51 +38,41 @@ class FullCurriculum extends React.Component {
             </H1Ref>
           </Col>
         </Row>
-          <Row>
-            <Col xs={12} md={12} lg={10} lgOffset={1}>
-              <P>Select Course:</P>
-            </Col>
-          </Row>
         <Row>
-        <Col>
-        <Tabs onChange={this.setActive} active={this.state.active}>
-            <TabList offset>
-              <TabItem name={REACT_BOOTCAMP}>
-                React 1-week bootcamp
-              </TabItem>
-              <TabItem name={ADVANCED_REACT}>
-                Advanced React bootcamp
-              </TabItem>
-              <TabItem name={REACT_NATIVE}>
-                React Native bootcamp
-              </TabItem>
-              <TabItem name={PART_TIME}>Part-time course</TabItem>
-            </TabList>
-          
-          
-          
-          <TabContent>
-            <ContentItem name={REACT_BOOTCAMP}>
-              <CurriculumBootcamp showTitle={false} />
-            </ContentItem>
-            <ContentItem name={ADVANCED_REACT}>
-              <CurriculumAdvancedReact showTitle={false} />
-            </ContentItem>
-            <ContentItem name={REACT_NATIVE}>
-              <CurriculumReactNative showTitle={false} />
-            </ContentItem>
-            <ContentItem name={PART_TIME}>
-              <CurriculumPartTime showTitle={false} />
-            </ContentItem>
-          </TabContent>
-        </Tabs>
-        </Col>
-       
-        
-      </Row>
-  </React.Fragment>
+          <Col xs={12} md={12} lg={10} lgOffset={1}>
+            <P>Select Course:</P>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <Tabs onChange={this.setActive} active={this.state.active}>
+              <TabList offset>
+                <TabItem name={REACT_BOOTCAMP}>React 1-week bootcamp</TabItem>
+                <TabItem name={ADVANCED_REACT}>Advanced React bootcamp</TabItem>
+                <TabItem name={REACT_NATIVE}>React Native bootcamp</TabItem>
+                <TabItem name={PART_TIME}>Part-time course</TabItem>
+              </TabList>
+
+              <TabContent>
+                <ContentItem name={REACT_BOOTCAMP}>
+                  <CurriculumBootcamp showTitle={false} />
+                </ContentItem>
+                <ContentItem name={ADVANCED_REACT}>
+                  <CurriculumAdvancedReact showTitle={false} />
+                </ContentItem>
+                <ContentItem name={REACT_NATIVE}>
+                  <CurriculumReactNative showTitle={false} />
+                </ContentItem>
+                <ContentItem name={PART_TIME}>
+                  <CurriculumPartTime showTitle={false} />
+                </ContentItem>
+              </TabContent>
+            </Tabs>
+          </Col>
+        </Row>
+      </React.Fragment>
     )
-  } 
-}  
+  }
+}
 
 export default FullCurriculum

--- a/src/components/curriculum/__snapshots__/CurriculumAdvancedReact.test.js.snap
+++ b/src/components/curriculum/__snapshots__/CurriculumAdvancedReact.test.js.snap
@@ -25,7 +25,7 @@ exports[`<CurriculumAdvancedReact /> should render component 1`] = `
       lgOffset={1}
       md={6}
     >
-      <CurriculumSection
+      <withRouter(CurriculumSection)
         name="day1"
         subTitle="Testing in React, Advanced React Patterns II, Server-side Rendering"
         title="Advanced React Day 1"
@@ -41,8 +41,8 @@ exports[`<CurriculumAdvancedReact /> should render component 1`] = `
         <ServerSideRenderingSession
           title="Server Side Rendering (SSR)"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day2"
         subTitle="Functional Programming, Advanced Patterns I, GraphQL, and Advanced Redux"
         title="Advanced React Day 2"
@@ -58,8 +58,8 @@ exports[`<CurriculumAdvancedReact /> should render component 1`] = `
         <AdvancedReduxSession
           title="Functional programming & advanced Redux"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day3"
         subTitle="Real-world Project"
         title="Advanced React Day 3"
@@ -69,7 +69,7 @@ exports[`<CurriculumAdvancedReact /> should render component 1`] = `
         <Hackathon
           title="Last day real-world React challenge. We'll implement an app in teams from scratch"
         />
-      </CurriculumSection>
+      </withRouter(CurriculumSection)>
       <styled.div>
         <LinkButton
           secondary={true}

--- a/src/components/curriculum/__snapshots__/CurriculumBootcamp.test.js.snap
+++ b/src/components/curriculum/__snapshots__/CurriculumBootcamp.test.js.snap
@@ -25,7 +25,7 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
       lgOffset={1}
       md={6}
     >
-      <CurriculumSection
+      <withRouter(CurriculumSection)
         name="day1"
         subTitle="React 101 and JS fundamentals"
         title="React Bootcamp Day 1 (half day)"
@@ -33,8 +33,8 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         type="React bootcamp"
       >
         <ReactJS101Session />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day2"
         subTitle="Modern JavaScript, Thinking in React, Routing & Data Fetching"
         title="React Bootcamp Day 2"
@@ -50,8 +50,8 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         <RoutingAndDataFetchingSession
           title="Routing and Data Fetching"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day3"
         subTitle="Forms, Authentication, Styling in React"
         title="React Bootcamp Day 3"
@@ -67,8 +67,8 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         <StylingInReactSession
           title="Styling in React"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day4"
         subTitle="Redux, and Testing Principles"
         title="React Bootcamp Day 4"
@@ -81,8 +81,8 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         <TestingIntroSession
           title="Testing Principales"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day5"
         subTitle="Functional Programming & advanced React patterns I, GraphQL, and Server-side Rendering"
         title="React Bootcamp Day 5"
@@ -98,8 +98,8 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         <ServerSideRenderingSession
           title="Server Side Rendering (SSR)"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day6"
         subTitle="Testing in React, Advanced React Patterns II, Functional Programming & advanced Redux"
         title="React Bootcamp Day 6"
@@ -115,8 +115,8 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         <AdvancedReduxSession
           title="Functional programming & advanced Redux"
         />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="day7"
         subTitle="Real-world Project"
         title="React Bootcamp Day 7"
@@ -126,7 +126,7 @@ exports[`<CurriculumBootcamp /> should render component 1`] = `
         <Hackathon
           title="Last day real-world React challenge. We'll implement an app in teams from scratch"
         />
-      </CurriculumSection>
+      </withRouter(CurriculumSection)>
       <styled.div>
         <LinkButton
           secondary={true}

--- a/src/components/curriculum/__snapshots__/CurriculumPartTime.test.js.snap
+++ b/src/components/curriculum/__snapshots__/CurriculumPartTime.test.js.snap
@@ -25,86 +25,86 @@ exports[`<CurriculumPartTime /> should render component 1`] = `
       lgOffset={1}
       md={6}
     >
-      <CurriculumSection
+      <withRouter(CurriculumSection)
         name="session1"
         title="Session 1 - Modern JavaScript"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <ES6Session />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session2"
         title="Session 2 - Thinking in React"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <ThinkingInReactSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session3"
         title="Session 3 - Routing & Data Fetching"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <RoutingAndDataFetchingSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session4"
         title="Session 4 - Forms & Auth"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <FormsAndAuthSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session5"
         title="Session 5 - Recap React Fundamentals"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <ReactFundamentalsRecapSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session6"
         title="Session 6 - Styling in React"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <StylingInReactSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session7"
         title="Session 7 - Introduction to Redux"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <IntroReduxSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session8"
         title="Session 8 - Introduction to Testing in JS"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <TestingIntroSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session9"
         title="Session 9 - Advanced Patterns I"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <HoCsAndRenderPropsSession />
-      </CurriculumSection>
-      <CurriculumSection
+      </withRouter(CurriculumSection)>
+      <withRouter(CurriculumSection)
         name="session10"
         title="Session 10 - React & Redux Real-world Project"
         toggleNavigateTo={[Function]}
         type="Part-time"
       >
         <PartTimeFinalProject />
-      </CurriculumSection>
+      </withRouter(CurriculumSection)>
     </Styled(Col)>
     <Styled(Col)
       lg={5}

--- a/src/components/curriculum/__snapshots__/CurriculumReactNative.test.js.snap
+++ b/src/components/curriculum/__snapshots__/CurriculumReactNative.test.js.snap
@@ -24,7 +24,7 @@ exports[`<CurriculumReactNative /> should render component 1`] = `
       lgOffset={1}
       md={6}
     >
-      <CurriculumSection
+      <withRouter(CurriculumSection)
         name="day1"
         subTitle="Foundation, Navigation, and Animations"
         title="React Native Day 1"
@@ -40,7 +40,7 @@ exports[`<CurriculumReactNative /> should render component 1`] = `
         <ReactNativeAnimationsSession
           title="Animations"
         />
-      </CurriculumSection>
+      </withRouter(CurriculumSection)>
     </Styled(Col)>
     <Styled(Col)
       lg={5}

--- a/src/components/elements/Card.js
+++ b/src/components/elements/Card.js
@@ -2,7 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { blue1, BROWN, WHITE, GREY2, BOX_SHADOW, reactBlue } from '../../config/styles'
+import {
+  blue1,
+  BROWN,
+  WHITE,
+  GREY2,
+  BOX_SHADOW,
+  reactBlue,
+} from '../../config/styles'
 import { SCREEN_XS_MAX, SCREEN_MD_MAX, SCREEN_SM_MIN } from '../utils'
 import { styleChildLinkColor } from '../navigation/Link'
 

--- a/src/components/elements/Ribbon.js
+++ b/src/components/elements/Ribbon.js
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import { FONT_FAMILY, TEXT_SIZE } from '../../config/styles'
 
-
 // export default styled.div`
 //   font-family: sans-serif;
 //   font-size: 0.9rem;

--- a/src/components/icons/Tick.js
+++ b/src/components/icons/Tick.js
@@ -1,10 +1,19 @@
 import React from 'react'
-import { selectTypeColor } from '../utils';
+import { selectTypeColor } from '../utils'
 
-const Tick = (props) => (
-    <svg xmlns="http://www.w3.org/2000/svg" width="35" height="27" viewBox="0 0 35 27">
-        <polygon fill={`${selectTypeColor(props.type)}`} fill-rule="evenodd" points="0 14.825 3.773 9.937 13.851 18.323 30.413 0 35 4.148 14.494 27"/>
-    </svg>
+const Tick = props => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="35"
+    height="27"
+    viewBox="0 0 35 27"
+  >
+    <polygon
+      fill={`${selectTypeColor(props.type)}`}
+      fill-rule="evenodd"
+      points="0 14.825 3.773 9.937 13.851 18.323 30.413 0 35 4.148 14.494 27"
+    />
+  </svg>
 )
 
 export default Tick

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -86,5 +86,5 @@ export {
   FacebookIcon,
   InstagramIcon,
   ExternalLinkIcon,
-  Tick
+  Tick,
 }

--- a/src/components/navigation/Link.js
+++ b/src/components/navigation/Link.js
@@ -67,10 +67,19 @@ const Link = ({ to = '', children = '', ...rest }) => {
       </BasicLink>
     )
   } else if (to && to[0] === '#') {
+    const { onClick, ...restLinkScrollProps } = rest
+
     return (
       <Route
         render={({ history }) => (
-          <LinkScroll {...rest} onClick={() => history.push(to)} to={to}>
+          <LinkScroll
+            {...restLinkScrollProps}
+            onClick={() => {
+              history.push(to)
+              onClick && onClick()
+            }}
+            to={to}
+          >
             {children}
           </LinkScroll>
         )}

--- a/src/components/navigation/Tabs.js
+++ b/src/components/navigation/Tabs.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { reactBlue, FONT_FAMILY } from '../../config/styles'
 import { SCREEN_XS_MAX, SCREEN_SM_MIN, selectTypeColor } from '../utils'
-import { REACT_BOOTCAMP, PART_TIME } from '../../config/data';
+import { REACT_BOOTCAMP, PART_TIME } from '../../config/data'
 import { Col, Row } from '../layout/Grid'
 
 const Ul = styled.ul`
@@ -56,24 +56,18 @@ export const TabList = ({ active, setActive, onChange, children, offset }) => {
   )
   return (
     <React.Fragment>
-      {offset ? 
+      {offset ? (
         <Row>
           <Col lgOffset={1}>
-            <Ul>
-              {compound}
-            </Ul>
+            <Ul>{compound}</Ul>
           </Col>
         </Row>
-      :
-        <Ul>
-          {compound}
-        </Ul>
-      }
+      ) : (
+        <Ul>{compound}</Ul>
+      )}
     </React.Fragment>
   )
 }
-  
-
 
 TabList.displayName = 'TabList'
 
@@ -94,18 +88,19 @@ const Li = styled.li`
    }
 `
 const A = styled.a`
-  ${props => 
-    `border-bottom: 3px solid ${selectTypeColor(props.name)}`  
-  };
+  ${props => `border-bottom: 3px solid ${selectTypeColor(props.name)}`};
   ${props => {
-    if (props.isActive && (props.name === PART_TIME || props.name === REACT_BOOTCAMP)) {
+    if (
+      props.isActive &&
+      (props.name === PART_TIME || props.name === REACT_BOOTCAMP)
+    ) {
       return `color: white !important`
     }
-  }}
+  }};
 `
 
 export const TabItem = ({ children, isActive, onClick, name, ...props }) => (
-  <Li isActive={isActive} name={name} >
+  <Li isActive={isActive} name={name}>
     <A isActive={isActive} name={name} {...props} onClick={onClick}>
       {children}
     </A>

--- a/src/components/payment/Countdown.js
+++ b/src/components/payment/Countdown.js
@@ -6,9 +6,9 @@ import { Col, Row } from '../layout/Grid.js'
 // import Span from '../text/Span.js'
 import styled from 'styled-components'
 
-const CountdownNumbers = styled.span `
-      font-size: 1.6rem;
-      text-align: center;
+const CountdownNumbers = styled.span`
+  font-size: 1.6rem;
+  text-align: center;
 `
 
 class Countdown extends Component {
@@ -95,20 +95,28 @@ class Countdown extends Component {
         <Row>
           <Col xs={2}>
             <React.Fragment>
-            <CountdownNumbers>{this.addLeadingZeros(countDown.days)}</CountdownNumbers>{' '}
-            <p>{countDown.days === 1 ? 'Day' : 'Days'}{' '}</p>
+              <CountdownNumbers>
+                {this.addLeadingZeros(countDown.days)}
+              </CountdownNumbers>{' '}
+              <p>{countDown.days === 1 ? 'Day' : 'Days'} </p>
             </React.Fragment>
           </Col>
           <Col xs={2}>
-            <CountdownNumbers>{this.addLeadingZeros(countDown.hours)}</CountdownNumbers>{' '}
+            <CountdownNumbers>
+              {this.addLeadingZeros(countDown.hours)}
+            </CountdownNumbers>{' '}
             <p>Hours</p>{' '}
           </Col>
           <Col xs={2}>
-            <CountdownNumbers>{this.addLeadingZeros(countDown.min)}</CountdownNumbers>{' '}
+            <CountdownNumbers>
+              {this.addLeadingZeros(countDown.min)}
+            </CountdownNumbers>{' '}
             <p>Min</p>{' '}
           </Col>
           <Col xs={2}>
-            <CountdownNumbers>{this.addLeadingZeros(countDown.sec)}</CountdownNumbers>{' '}
+            <CountdownNumbers>
+              {this.addLeadingZeros(countDown.sec)}
+            </CountdownNumbers>{' '}
             <p>Sec</p>
           </Col>
         </Row>

--- a/src/components/payment/PaymentSection.js
+++ b/src/components/payment/PaymentSection.js
@@ -139,7 +139,9 @@ class PaymentSection extends React.Component {
         </P>
         <Card small style={{ position: 'relative' }}>
           <H3>
-            <strong>{discountPrice ? 'Discount ticket' : 'Regular ticket'}</strong>
+            <strong>
+              {discountPrice ? 'Discount ticket' : 'Regular ticket'}
+            </strong>
           </H3>
           {discountPrice ? (
             <Ribbon>
@@ -155,13 +157,10 @@ class PaymentSection extends React.Component {
           )}
           {priceGoesUpOn > Date.now() ? (
             <React.Fragment>
-                <P>
-                  HURRY! This price is only available for...
-                </P>
-                <P>
+              <P>HURRY! This price is only available for...</P>
+              <P>
                 <Countdown date={priceGoesUpOn} />
               </P>
-
             </React.Fragment>
           ) : (
             ''

--- a/src/components/payment/ScholarshipsCard.js
+++ b/src/components/payment/ScholarshipsCard.js
@@ -6,7 +6,7 @@ import { TradeLedger } from '../../components/logos'
 import Card from '../elements/Card'
 
 const ScholarshipsCard = () => (
-  <Card top={36} bottom={36} bg='reactBlue' small>
+  <Card top={36} bottom={36} bg="reactBlue" small>
     <H3>Scholarship available!</H3>
     <P>
       Looking to code React full time? We've partnered with Trade Ledger to

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -5,7 +5,7 @@ import { selectTypeColor } from '../utils'
 import { FONT_FAMILY } from '../../config/styles'
 
 const Table = styled(responsiveTable.Table)`
-    ${FONT_FAMILY}
+  ${FONT_FAMILY};
 `
 
 const Thead = responsiveTable.Thead
@@ -13,12 +13,14 @@ const Tbody = responsiveTable.Tbody
 const Tr = responsiveTable.Tr
 
 const Th = styled(responsiveTable.Th)`
-    text-align: center;
-    ${props => props.type ? `border-bottom 3px solid ${selectTypeColor(props.type)}` : 'border: none;'}
+  text-align: center;
+  ${props =>
+    props.type
+      ? `border-bottom 3px solid ${selectTypeColor(props.type)}`
+      : 'border: none;'};
 `
 const Td = styled(responsiveTable.Td)`
-    text-align: center;
+  text-align: center;
 `
-
 
 export { Table, Thead, Tbody, Tr, Th, Td }

--- a/src/components/training/TrainingItem.js
+++ b/src/components/training/TrainingItem.js
@@ -5,7 +5,7 @@ import { Col, Row } from '../layout/Grid'
 import { LinkButton } from '../buttons'
 import Link from '../navigation/Link'
 import { Image } from '../elements'
-import { selectTypeColor } from '../utils';
+import { selectTypeColor } from '../utils'
 
 const TrainingItemCol = styled(Col)`
   padding-bottom: 16px;
@@ -26,27 +26,33 @@ const Calander = styled.div`
   font-size: 1.1em;
 `
 
-const TrainingItem = ({ type, city, country, startDay, startMonth, path, imageSrc }) => (
+const TrainingItem = ({
+  type,
+  city,
+  country,
+  startDay,
+  startMonth,
+  path,
+  imageSrc,
+}) => (
   <React.Fragment>
     <TrainingRow>
-    <TrainingItemCol xs={5} md={3}>
-      <Calander type={type}>
-        {startDay}
-        <br />
-        {startMonth}
-      </Calander>
-    </TrainingItemCol>
-    <TrainingItemCol xs={7} md={7}>
-      <P>
-        {type}
-        <br />
-        {city}, {country}
-        <br />
-      <Link to={path}>
-        Find out more
-      </Link>
-      </P>
-    </TrainingItemCol>
+      <TrainingItemCol xs={5} md={3}>
+        <Calander type={type}>
+          {startDay}
+          <br />
+          {startMonth}
+        </Calander>
+      </TrainingItemCol>
+      <TrainingItemCol xs={7} md={7}>
+        <P>
+          {type}
+          <br />
+          {city}, {country}
+          <br />
+          <Link to={path}>Find out more</Link>
+        </P>
+      </TrainingItemCol>
     </TrainingRow>
   </React.Fragment>
 )

--- a/src/components/training/UpcomingTrainingSection.js
+++ b/src/components/training/UpcomingTrainingSection.js
@@ -5,66 +5,56 @@ import { H2, H3 } from '../text'
 import { TrainingItem, TrainingList } from './'
 import moment from 'moment'
 
-import { selectTrainings } from '../../config/data' 
-
+import { selectTrainings } from '../../config/data'
 
 const trainings = selectTrainings()
 
-const UpcomingTrainings = ({curriculum}) => trainings.map(training => {
-  const trainingInstance =   
-    <TrainingItem
-      key={training.trainingInstanceId}
-      city={training.city}
-      country={training.country}
-      startDay={moment(training.dateStartsOn).format('D')}
-      startMonth={moment(training.dateStartsOn).format('MMM')}
-      type={training.type}
-      path={training.pathUrl}
-  />
-  return (
-    <React.Fragment key={training.trainingInstanceId}>
-      {curriculum ? 
-        trainingInstance
-        :
-        <Col md={4}>
-          {trainingInstance}
-        </Col>
-        }
-    </React.Fragment>
-  )
-}
-  
-)
+const UpcomingTrainings = ({ curriculum }) =>
+  trainings.map(training => {
+    const trainingInstance = (
+      <TrainingItem
+        key={training.trainingInstanceId}
+        city={training.city}
+        country={training.country}
+        startDay={moment(training.dateStartsOn).format('D')}
+        startMonth={moment(training.dateStartsOn).format('MMM')}
+        type={training.type}
+        path={training.pathUrl}
+      />
+    )
+    return (
+      <React.Fragment key={training.trainingInstanceId}>
+        {curriculum ? trainingInstance : <Col md={4}>{trainingInstance}</Col>}
+      </React.Fragment>
+    )
+  })
 
-
-const UpcomingTrainingSection = ({curriculum}) => (
+const UpcomingTrainingSection = ({ curriculum }) => (
+  <React.Fragment>
+    {curriculum ? (
       <React.Fragment>
-        {curriculum ?
-          <React.Fragment>
-            <H3 style={{marginTop: '1em'}}>Upcoming courses</H3>
-            <UpcomingTrainings curriculum={curriculum} />
-          </React.Fragment>
-          :
-          <Section>
-            <Grid>
-              <Row>
-                <Col md={10} mdOffset={1}>
-              <H2>
-                  Upcoming Training
-              </H2>
-                </Col>
-                </Row>
-              <Row>
-                <Col md={11} mdOffset={1}>
-                <TrainingList>
-                  <UpcomingTrainings curriculum={curriculum} />
-                </TrainingList>
-                </Col>
-              </Row>
-            </Grid>
-          </Section>
-        }
+        <H3 style={{ marginTop: '1em' }}>Upcoming courses</H3>
+        <UpcomingTrainings curriculum={curriculum} />
+      </React.Fragment>
+    ) : (
+      <Section>
+        <Grid>
+          <Row>
+            <Col md={10} mdOffset={1}>
+              <H2>Upcoming Training</H2>
+            </Col>
+          </Row>
+          <Row>
+            <Col md={11} mdOffset={1}>
+              <TrainingList>
+                <UpcomingTrainings curriculum={curriculum} />
+              </TrainingList>
+            </Col>
+          </Row>
+        </Grid>
+      </Section>
+    )}
   </React.Fragment>
-  )
+)
 
 export default UpcomingTrainingSection

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
-import { REACT_NATIVE, REACT_BOOTCAMP, PART_TIME, ADVANCED_REACT } from '../../config/data'
+import {
+  REACT_NATIVE,
+  REACT_BOOTCAMP,
+  PART_TIME,
+  ADVANCED_REACT,
+} from '../../config/data'
 import { GREY2, YELLOW, LIGHT_RED, REACT_BLUE_DARK } from '../../config/styles'
 
 export const SCREEN_XS_MAX = '767px'
@@ -17,19 +22,19 @@ const Components = ({ children, ...props }) =>
     })
   )
 
-export const selectTypeColor = (type) => {
-switch (type) {
+export const selectTypeColor = type => {
+  switch (type) {
     case REACT_BOOTCAMP:
-        return REACT_BLUE_DARK
+      return REACT_BLUE_DARK
     case PART_TIME:
-        return  GREY2
+      return GREY2
     case REACT_NATIVE:
-        return  LIGHT_RED
+      return LIGHT_RED
     case ADVANCED_REACT:
-        return YELLOW
+      return YELLOW
     default:
-        return REACT_BLUE_DARK    
-    }
+      return REACT_BLUE_DARK
+  }
 }
 
 export const HideComponentsUsingCss = styled(Components)`

--- a/src/config/styles.js
+++ b/src/config/styles.js
@@ -4,7 +4,7 @@ export const reactBlue = (opacity = 1) => `rgba(111, 207, 240, ${opacity})` // #
 
 export const blue1 = (opacity = 1) => `rgba(0,41,56, ${opacity})` // #002938
 
-export const blue2 = (opacity = 1) => `rgba(87,178,212,${opacity})` 
+export const blue2 = (opacity = 1) => `rgba(87,178,212,${opacity})`
 
 export const REACT_BLUE_DARK = '#57B2D4'
 

--- a/src/pages/curriculum.js
+++ b/src/pages/curriculum.js
@@ -5,7 +5,7 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '../components/table'
 import Section, { TopSection } from '../components/layout/Section'
 import Grid, { Col, Row } from '../components/layout/Grid'
 import Ul, { Li } from '../components/layout/Ul'
-import { H2Ref, H2, P, H3 } from '../components/text'
+import { H2Ref, H2, P, H3, H4 } from '../components/text'
 import LinkButton from '../components/buttons/LinkButton'
 import {
   Link,
@@ -294,54 +294,7 @@ class Curriculum extends React.Component {
                           improve your React apps development and performance
                         </Li>
                       </Ul>
-                      <Row>
-                        <Col md={2}>
-                          <Ul inline>
-                            <Li>Jump to:</Li>
-                          </Ul>
-                        </Col>
-                        <Col md={10}>
-                          <Ul unstyled>
-                            <Li>
-                              <Link to="#day1">
-                                Day 1 (half day): React 101 and JS fundamentals
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#day2">
-                                Day 2: ES6 & ESNEXT, Thinking in React, Routing
-                                & Data Fetching
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#day3">
-                                Day 3: Forms, Authentication, Styling in React
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#day4">
-                                Day 4: Redux, and Testing Principles
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#day5">
-                                Day 5: FP & advanced React patterns I, GraphQL,
-                                Server-side rendering
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#day6">
-                                Day 6: Testing in React, Advanced React patterns
-                                II, FP & advanced Redux
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#day7">Day 7: Real world project</Link>
-                            </Li>
-                          </Ul>
-                        </Col>
-                      </Row>
-
+                      <H4>Full course curriculum:</H4>
                       <Row>
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
@@ -392,6 +345,7 @@ class Curriculum extends React.Component {
                           improve your React apps development and performance
                         </Li>
                       </Ul>
+                      <H4>Full course curriculum:</H4>
                       <Row>
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
@@ -436,6 +390,7 @@ class Curriculum extends React.Component {
                           applications
                         </Li>
                       </Ul>
+                      <H4>Full course curriculum:</H4>
                       <Row>
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
@@ -473,65 +428,7 @@ class Curriculum extends React.Component {
                           real-world production-ready React applications
                         </Li>
                       </Ul>
-                      <Row>
-                        <Col md={2}>
-                          <Ul inline>
-                            <Li>Jump to:</Li>
-                          </Ul>
-                        </Col>
-                        <Col md={10}>
-                          <Ul unstyled>
-                            <Li>
-                              <Link to="#session1">Session 1: ES6</Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session2">
-                                Session 2: Thinking in React
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session3">
-                                Session 3: Routing & Data Fetching
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session4">
-                                Session 4: Forms & Auth
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session5">
-                                Session 5: Recap React Fundamentals
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session6">
-                                Session 6: Styling in React
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session7">
-                                Session 7: Introduction to Redux
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session8">
-                                Session 8: Introduction to Testing in JS
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session9">
-                                Session 9: Advanced React Patterns
-                              </Link>
-                            </Li>
-                            <Li>
-                              <Link to="#session10">
-                                Session 10: React mini
-                              </Link>
-                            </Li>
-                          </Ul>
-                        </Col>
-                      </Row>
+                      <H4>Full course curriculum:</H4>
 
                       <Row>
                         <Col lg={1} lgOffset={1} />

--- a/src/pages/curriculum.js
+++ b/src/pages/curriculum.js
@@ -34,7 +34,7 @@ import {
   REACT_BOOTCAMP,
   ADVANCED_REACT,
   PART_TIME,
-  REACT_NATIVE
+  REACT_NATIVE,
 } from '../config/data'
 
 const trainingBootcamp = selectFirstTraining(REACT_BOOTCAMP)
@@ -104,82 +104,139 @@ class Curriculum extends React.Component {
               </Row>
               <Row>
                 <Col lg={10} lgOffset={1}>
-                <Table>
-                  <Thead>
-                    <Tr>
-                      <Th></Th>
-                      <Th type={REACT_BOOTCAMP}>One week bootcamp</Th>
-                      <Th type={ADVANCED_REACT}>Advanced bootcamp</Th>
-                      <Th type={REACT_NATIVE}>React Native training</Th>
-                      <Th type={PART_TIME}>Part time course</Th>
-                    </Tr>
-                  </Thead>
-                  <Tbody>
-                    <Tr>
-                      <Td>ES6</Td>
-                      <Td><Tick type={REACT_BOOTCAMP}/></Td>
-                      <Td></Td>
-                      <Td></Td>
-                      <Td><Tick type={PART_TIME}/></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>Routing in React</Td>
-                      <Td><Tick type={REACT_BOOTCAMP}/></Td>
-                      <Td></Td>
-                      <Td></Td>
-                      <Td><Tick type={PART_TIME}/></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>Forms and authentication</Td>
-                      <Td><Tick type={REACT_BOOTCAMP}/></Td>
-                      <Td></Td>
-                      <Td></Td>
-                      <Td><Tick type={PART_TIME}/></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>Testing</Td>
-                      <Td><Tick type={REACT_BOOTCAMP}/></Td>
-                      <Td><Tick type={ADVANCED_REACT}/></Td>
-                      <Td></Td>
-                      <Td><Tick type={PART_TIME}/></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>GraphQL</Td>
-                      <Td><Tick type={REACT_BOOTCAMP}/></Td>
-                      <Td><Tick type={ADVANCED_REACT}/></Td>
-                      <Td></Td>
-                      <Td></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>Adv. React patterns</Td>
-                      <Td><Tick type={REACT_BOOTCAMP}/></Td>
-                      <Td><Tick type={ADVANCED_REACT}/></Td>
-                      <Td></Td>
-                      <Td><Tick type={PART_TIME}/></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>Animations</Td>
-                      <Td></Td>
-                      <Td></Td>
-                      <Td><Tick type={REACT_NATIVE}/></Td>
-                      <Td></Td>
-                    </Tr>
-                    <Tr>
-                      <Td>Gestures</Td>
-                      <Td></Td>
-                      <Td></Td>
-                      <Td><Tick type={REACT_NATIVE}/></Td>
-                      <Td></Td>
-                    </Tr>
-                    <Tr>
-                      <Td></Td>
-                      <Td><LinkButton secondary to="/react-redux-graphql-bootcamp">React bootcamp >></LinkButton></Td>
-                      <Td><LinkButton secondary to="/advanced-react-redux-graphql-bootcamp">Advanced bootcamp >></LinkButton></Td>
-                      <Td><LinkButton secondary to="/react-native-bootcamp">React Native >></LinkButton></Td>
-                      <Td><LinkButton secondary to="/react-redux-graphql-part-time-course">Part Time >></LinkButton></Td>
-                    </Tr>
-                  </Tbody>
-                </Table>
+                  <Table>
+                    <Thead>
+                      <Tr>
+                        <Th />
+                        <Th type={REACT_BOOTCAMP}>One week bootcamp</Th>
+                        <Th type={ADVANCED_REACT}>Advanced bootcamp</Th>
+                        <Th type={REACT_NATIVE}>React Native training</Th>
+                        <Th type={PART_TIME}>Part time course</Th>
+                      </Tr>
+                    </Thead>
+                    <Tbody>
+                      <Tr>
+                        <Td>ES6</Td>
+                        <Td>
+                          <Tick type={REACT_BOOTCAMP} />
+                        </Td>
+                        <Td />
+                        <Td />
+                        <Td>
+                          <Tick type={PART_TIME} />
+                        </Td>
+                      </Tr>
+                      <Tr>
+                        <Td>Routing in React</Td>
+                        <Td>
+                          <Tick type={REACT_BOOTCAMP} />
+                        </Td>
+                        <Td />
+                        <Td />
+                        <Td>
+                          <Tick type={PART_TIME} />
+                        </Td>
+                      </Tr>
+                      <Tr>
+                        <Td>Forms and authentication</Td>
+                        <Td>
+                          <Tick type={REACT_BOOTCAMP} />
+                        </Td>
+                        <Td />
+                        <Td />
+                        <Td>
+                          <Tick type={PART_TIME} />
+                        </Td>
+                      </Tr>
+                      <Tr>
+                        <Td>Testing</Td>
+                        <Td>
+                          <Tick type={REACT_BOOTCAMP} />
+                        </Td>
+                        <Td>
+                          <Tick type={ADVANCED_REACT} />
+                        </Td>
+                        <Td />
+                        <Td>
+                          <Tick type={PART_TIME} />
+                        </Td>
+                      </Tr>
+                      <Tr>
+                        <Td>GraphQL</Td>
+                        <Td>
+                          <Tick type={REACT_BOOTCAMP} />
+                        </Td>
+                        <Td>
+                          <Tick type={ADVANCED_REACT} />
+                        </Td>
+                        <Td />
+                        <Td />
+                      </Tr>
+                      <Tr>
+                        <Td>Adv. React patterns</Td>
+                        <Td>
+                          <Tick type={REACT_BOOTCAMP} />
+                        </Td>
+                        <Td>
+                          <Tick type={ADVANCED_REACT} />
+                        </Td>
+                        <Td />
+                        <Td>
+                          <Tick type={PART_TIME} />
+                        </Td>
+                      </Tr>
+                      <Tr>
+                        <Td>Animations</Td>
+                        <Td />
+                        <Td />
+                        <Td>
+                          <Tick type={REACT_NATIVE} />
+                        </Td>
+                        <Td />
+                      </Tr>
+                      <Tr>
+                        <Td>Gestures</Td>
+                        <Td />
+                        <Td />
+                        <Td>
+                          <Tick type={REACT_NATIVE} />
+                        </Td>
+                        <Td />
+                      </Tr>
+                      <Tr>
+                        <Td />
+                        <Td>
+                          <LinkButton
+                            secondary
+                            to="/react-redux-graphql-bootcamp"
+                          >
+                            React bootcamp >>
+                          </LinkButton>
+                        </Td>
+                        <Td>
+                          <LinkButton
+                            secondary
+                            to="/advanced-react-redux-graphql-bootcamp"
+                          >
+                            Advanced bootcamp >>
+                          </LinkButton>
+                        </Td>
+                        <Td>
+                          <LinkButton secondary to="/react-native-bootcamp">
+                            React Native >>
+                          </LinkButton>
+                        </Td>
+                        <Td>
+                          <LinkButton
+                            secondary
+                            to="/react-redux-graphql-part-time-course"
+                          >
+                            Part Time >>
+                          </LinkButton>
+                        </Td>
+                      </Tr>
+                    </Tbody>
+                  </Table>
                 </Col>
               </Row>
             </Card>
@@ -199,9 +256,7 @@ class Curriculum extends React.Component {
                     <TabItem name={ADVANCED_REACT}>
                       Advanced React bootcamp
                     </TabItem>
-                    <TabItem name={REACT_NATIVE}>
-                      React Native bootcamp
-                    </TabItem>
+                    <TabItem name={REACT_NATIVE}>React Native bootcamp</TabItem>
                     <TabItem name={PART_TIME}>Part-time course</TabItem>
                   </TabList>
                   <TabContent>
@@ -291,7 +346,7 @@ class Curriculum extends React.Component {
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
                           <CurriculumBootcamp
-                            showToggle={false}
+                            enableToggle={true}
                             showTitle={false}
                             showLinkToCurriculum={false}
                             list={true}
@@ -341,9 +396,10 @@ class Curriculum extends React.Component {
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
                           <CurriculumAdvancedReact
-                            showToggle={false}
+                            enableToggle={true}
                             showTitle={false}
                             list={true}
+                            showLinkToCurriculum={false}
                             marketingCard={
                               <MarketingCard
                                 text={`Next advanced React bootcamp starts on ${moment(
@@ -384,7 +440,8 @@ class Curriculum extends React.Component {
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
                           <CurriculumReactNative
-                            showToggle={false}
+                            isOpen={true}
+                            enableToggle={true}
                             showTitle={false}
                             list={true}
                           />
@@ -480,7 +537,7 @@ class Curriculum extends React.Component {
                         <Col lg={1} lgOffset={1} />
                         <Col lg={9}>
                           <CurriculumPartTime
-                            showToggle={false}
+                            enableToggle={true}
                             showTitle={false}
                             list={true}
                             marketingCard={

--- a/src/pages/curriculum.js
+++ b/src/pages/curriculum.js
@@ -137,7 +137,7 @@ class Curriculum extends React.Component {
                       <Td><Tick type={PART_TIME}/></Td>
                     </Tr>
                     <Tr>
-                      <Td>Testing in React</Td>
+                      <Td>Testing</Td>
                       <Td><Tick type={REACT_BOOTCAMP}/></Td>
                       <Td><Tick type={ADVANCED_REACT}/></Td>
                       <Td></Td>
@@ -148,7 +148,7 @@ class Curriculum extends React.Component {
                       <Td><Tick type={REACT_BOOTCAMP}/></Td>
                       <Td><Tick type={ADVANCED_REACT}/></Td>
                       <Td></Td>
-                      <Td><Tick type={PART_TIME}/></Td>
+                      <Td></Td>
                     </Tr>
                     <Tr>
                       <Td>Adv. React patterns</Td>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -64,7 +64,6 @@ const PostMeta = ({ author = 'richard', date = '', timeToRead }) => (
   </StyledAuthor>
 )
 
-
 const GridContent = styled(Grid)`
   padding-top: 72px;
 `
@@ -84,8 +83,8 @@ const BlogPost = ({ data }) => {
   return (
     <React.Fragment>
       <Helmet>
-        <meta property="og:title" content={title}/>
-        <meta property="og:image" content={imageUrl}/>
+        <meta property="og:title" content={title} />
+        <meta property="og:image" content={imageUrl} />
         <meta property="og:description" content={subtitle} />
         <meta property="og:type" content="article" />
       </Helmet>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11680,13 +11680,6 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
-  dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -13831,10 +13824,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-
 string-argv@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
@@ -14860,6 +14849,10 @@ url-parse@^1.1.8, url-parse@^1.4.3:
   dependencies:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
+
+url-search-params-polyfill@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-5.0.0.tgz#09b98337c89dcf6c6a6a0bfeb096f6ba83b7526b"
 
 url-to-options@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3861,6 +3861,13 @@ create-react-class@^15.6.0, create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-env@^3.1.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-3.2.4.tgz#9e0585f277864ed421ce756f81a980ff0d698aba"
@@ -5084,12 +5091,11 @@ event-emitter@^0.3.5, event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-event-stream@~3.3.0:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.6.tgz#cac1230890e07e73ec9cacd038f60a5b66173eef"
+event-stream@^4.0.1, event-stream@~3.3.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-4.0.1.tgz#4092808ec995d0dd75ea4580c1df6a74db2cde65"
   dependencies:
     duplexer "^0.1.1"
-    flatmap-stream "^0.1.0"
     from "^0.1.7"
     map-stream "0.0.7"
     pause-stream "^0.0.11"
@@ -5446,7 +5452,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.12, fbjs@^0.8.14, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -5756,10 +5762,6 @@ flat@^2.0.1:
   resolved "https://registry.yarnpkg.com/flat/-/flat-2.0.1.tgz#70e29188a74be0c3c89409eed1fa9577907ae32f"
   dependencies:
     is-buffer "~1.1.2"
-
-flatmap-stream@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/flatmap-stream/-/flatmap-stream-0.1.0.tgz#ed54e01422cd29281800914fcb968d58b685d5f1"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -6785,6 +6787,10 @@ gtoken@^2.3.0:
     jws "^3.1.4"
     mime "^2.2.0"
     pify "^3.0.0"
+
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -11674,6 +11680,13 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.2.0.tgz#468edeb542b7e0538f9f9b1aeb26f034f19c86e1"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -12044,6 +12057,12 @@ react-styled-flexboxgrid@^2.4.0:
   resolved "https://registry.yarnpkg.com/react-styled-flexboxgrid/-/react-styled-flexboxgrid-2.4.0.tgz#208474f068b12abf4550c3918c9481ab750cc79e"
   dependencies:
     lodash.isinteger "^4.0.4"
+
+react-super-responsive-table@^4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/react-super-responsive-table/-/react-super-responsive-table-4.3.5.tgz#c3fa253cadc3dffa23450734cfeaa68d9b6cf772"
+  dependencies:
+    create-react-context "^0.2.3"
 
 react-test-renderer@^16.0.0-0:
   version "16.4.2"
@@ -13811,6 +13830,10 @@ stream-to-observable@^0.1.0:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
 
 string-argv@^0.0.2:
   version "0.0.2"


### PR DESCRIPTION
This is a refactoring of the "show more" toggle button that was implemented in V1. Changes:
- Adds more semantic toggle props to the CurriculumSection.
- Sets isOpen on the curriculum section based on the query string parameters
- Enables toggle sections in the curriculum page