### PR TITLE
fix warning on passing secondary prop to LinkScroll

### DIFF
--- a/src/components/layout/AcceptCookies.js
+++ b/src/components/layout/AcceptCookies.js
@@ -65,7 +65,7 @@ class AcceptCookies extends React.Component {
           <div>
             Using our site means you consent to our use of cookies. Find out
             more in our{' '}
-            <Link inheritFontSize to="/privacy-policy">
+            <Link to="/privacy-policy">
               privacy policy
             </Link>
             .

--- a/src/components/navigation/Link.js
+++ b/src/components/navigation/Link.js
@@ -44,9 +44,9 @@ const RouterLink = styled(GatsbyLink)`
   ${ANCHOR_STYLE};
 `
 
-export const LinkScroll = styled(({ to, ...rest }) => (
+export const LinkScroll = styled(({ to, secondary, ...rest }) => (
   <DefaultLinkScroll
-    smooth={true}
+    smooth
     duration={500}
     offset={DEFAULT_SCROLL_OFFSET}
     to={to && to.slice(1, to.length)}


### PR DESCRIPTION
- fix `secondary` prop warning. it was passed to LinkScroll and it was complaining.
- fix `inheritFontSize` prop. it was passed to AcceptCookies component link and it was complaining