### PR TITLE
remove internal curriculum link from product menu

### DIFF
--- a/src/components/layout/Header.json
+++ b/src/components/layout/Header.json
@@ -6,10 +6,6 @@
         "to": "#pricing"
       },
       {
-        "text": "Curriculum",
-        "to": "#curriculum"
-      },
-      {
         "text": "Is it right for me?",
         "to": "#target-audience"
       }


### PR DESCRIPTION
the curriculum on every product does not exist, and the `#curriculum` link was dead. I remove it